### PR TITLE
fix: remove invalid inputs from run-gemini-cli workflows

### DIFF
--- a/.github/workflows/fix-agent.yml
+++ b/.github/workflows/fix-agent.yml
@@ -259,7 +259,6 @@ jobs:
             Do NOT run `gh pr comment`, `gh api` to post comments, or any command that
             posts to the PR. Comment posting is handled by a separate automated step.
           upload_artifacts: 'true'
-          github_pr_number: '${{ steps.pr.outputs.number }}'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -300,7 +299,6 @@ jobs:
             Do NOT run `gh pr comment`, `gh api` to post comments, or any command that
             posts to the PR. Comment posting is handled by a separate automated step.
           upload_artifacts: 'true'
-          github_pr_number: '${{ steps.pr.outputs.number }}'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/implementation-agent.yml
+++ b/.github/workflows/implementation-agent.yml
@@ -122,7 +122,6 @@ jobs:
             IMPORTANT: Follow the "Posting Comments" section in implement-from-issue.md
             for in-place comment updates using the <!-- fullsend:implementation-agent --> marker.
           upload_artifacts: 'true'
-          github_issue_number: '${{ github.event.issue.number }}'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_BRANCH: ${{ env.TARGET_BRANCH }}

--- a/.github/workflows/triage-agent.yml
+++ b/.github/workflows/triage-agent.yml
@@ -87,6 +87,5 @@ jobs:
             IMPORTANT: Follow the "Posting Comments" section in triage-issue.md
             for in-place comment updates using the <!-- fullsend:triage-agent --> marker.
           upload_artifacts: 'true'
-          github_issue_number: '${{ github.event.issue.number }}'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Remove `github_issue_number` from triage-agent and implementation-agent workflows
- Remove `github_pr_number` from fix-agent workflow (both bot and human triggers)
- These inputs are not accepted by `google-github-actions/run-gemini-cli@v0.1.21` and cause the Gemini CLI step to fail with `Invalid value. Matching delimiter not found 'EOF'`

## Test plan
- [x] Review agent triggers and approves successfully
- [ ] Triage agent triggers successfully on a new issue
- [ ] Fix agent triggers successfully on review feedback