### PR TITLE
fix: use gemini-3-flash-preview for triage agent

### DIFF
--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -141,7 +141,7 @@ jobs:
 
             IMPORTANT: Read and follow the GEMINI.md rules before reviewing.
             The Gemini model names used in workflow files (e.g. gemini-3.1-pro-preview,
-            gemini-3.1-flash-preview) are correct and intentional. Do NOT flag them as
+            gemini-3-flash-preview) are correct and intentional. Do NOT flag them as
             invalid or suggest reverting to older model versions. Your training data
             may not include these models — trust the GEMINI.md specification.
 

--- a/.github/workflows/triage-agent.yml
+++ b/.github/workflows/triage-agent.yml
@@ -60,7 +60,7 @@ jobs:
         uses: google-github-actions/run-gemini-cli@v0.1.21
         with:
           gemini_api_key: ${{ secrets.AI_API_KEY }}
-          gemini_model: gemini-3.1-flash-preview
+          gemini_model: gemini-3-flash-preview
           settings: |
             {
               "tools": {

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -65,7 +65,7 @@ runs to validate component builds before promotion.
 - This project pins specific Gemini model versions in workflow files. The model
   identifiers are set by the project maintainers and validated against the
   Google AI Studio API before deployment.
-- Model names like `gemini-3.1-pro-preview` and `gemini-3.1-flash-preview` are
+- Model names like `gemini-3.1-pro-preview` and `gemini-3-flash-preview` are
   intentional. These may be newer than your training data — accept them as-is.
 - Do not suggest changing model versions during code review.
 


### PR DESCRIPTION
## Summary
- `gemini-3.1-flash-preview` does not exist in the Gemini API — only the pro variant has a 3.1 version
- Update triage agent model to `gemini-3-flash-preview`
- Update GEMINI.md and review agent prompt text to match

## Test plan
- [ ] Triage agent triggers successfully on a new issue