### PR TITLE
fix: restructure triage agent to use deterministic post-step

### DIFF
--- a/.gemini/commands/triage-issue.md
+++ b/.gemini/commands/triage-issue.md
@@ -1,29 +1,38 @@
 # Triage Issue
 
-Classify a GitHub issue and apply labels.
+Classify a GitHub issue and write triage results to a file.
 
 ## Steps
 
-1. Read the issue title, body, and comments from `issue_body.txt`
-2. Determine the type: `kind/bug`, `kind/feature`, `kind/enhancement`, `kind/docs`, `kind/chore`
-3. Determine the area: `area/controller`, `area/api`, `area/gitops`, `area/tekton`, `area/test`
-4. Determine priority: `priority/critical`, `priority/high`, `priority/medium`, `priority/low`
-5. Apply labels using `gh issue edit <number> --add-label <labels>`
-6. If the issue has enough detail for implementation, also add `ready-for-implementation`
-7. If the issue lacks detail, post a comment asking for clarification
-8. Post a triage summary comment on the issue (see Posting Comments below)
+1. Read the pre-fetched issue content from the file path provided in the prompt
+2. Read the codebase as needed to understand the issue context
+3. Determine the type: `kind/bug`, `kind/feature`, `kind/enhancement`, `kind/docs`, `kind/chore`
+4. Determine the area: `area/controller`, `area/api`, `area/gitops`, `area/tekton`, `area/test`
+5. Determine priority: `priority/critical`, `priority/high`, `priority/medium`, `priority/low`
+6. If the issue has enough detail for implementation, include `ready-for-implementation` in labels
+7. Write the triage output file (path provided in the prompt) in this exact format:
 
-## Posting Comments (In-Place Update with History)
-
-When posting status updates on issues or PRs, use the provided update-comment script:
-
-```bash
-.github/scripts/update-comment.sh "{owner}/{repo}" "<number>" "<!-- fullsend:triage-agent -->" "<your new content here>"
 ```
+LABELS: kind/bug,area/controller,priority/high,ready-for-implementation
+---
+### Triage Summary
+- **Type**: kind/bug
+- **Area**: area/controller
+- **Priority**: priority/high
+- **Ready for Implementation**: yes/no
+
+<your detailed analysis here>
+```
+
+The first line MUST start with `LABELS:` followed by a comma-separated list.
+The `---` separator MUST appear on its own line after the labels.
+Everything after `---` is the triage summary in markdown.
 
 ## Constraints
 
+- Do NOT use `gh` commands — you do not have access to the GitHub CLI
+- Do NOT post comments or apply labels — a later workflow step handles that
 - Do NOT modify any code files
 - Do NOT create branches or PRs
-- Only add labels and post comments
+- Only read files and write the triage output file
 - If you cannot determine a category, use the most general option

--- a/.github/workflows/triage-agent.yml
+++ b/.github/workflows/triage-agent.yml
@@ -135,7 +135,7 @@ jobs:
           sed -i 's/\r$//' "$TRIAGE_FILE"
           
           # Extract labels safely, ignoring potential markdown codeblock wrappers
-          LABELS=$(grep '^LABELS:' "$TRIAGE_FILE" | head -1 | sed 's/^LABELS:[[:space:]]*//')
+          LABELS=$(sed -n 's/^LABELS:[[:space:]]*//p' "$TRIAGE_FILE" | head -1)
           # Extract summary (everything after the --- separator)
           SUMMARY=$(sed '1,/^---$/d' "$TRIAGE_FILE")
 

--- a/.github/workflows/triage-agent.yml
+++ b/.github/workflows/triage-agent.yml
@@ -55,6 +55,23 @@ jobs:
           app-id: ${{ secrets.AGENT_APP_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
 
+      - name: Prepare triage inputs
+        if: steps.scan.outputs.detected != 'true'
+        id: triage-path
+        run: |
+          HASH=$(openssl rand -hex 8)
+          ISSUE_FILE="/tmp/issue-${GITHUB_RUN_ID}-${HASH}.txt"
+          TRIAGE_FILE="/tmp/triage-${GITHUB_RUN_ID}-${HASH}.md"
+          echo "issue=$ISSUE_FILE" >> "$GITHUB_OUTPUT"
+          echo "file=$TRIAGE_FILE" >> "$GITHUB_OUTPUT"
+
+          # Pre-fetch issue data so Gemini doesn't need gh access
+          gh issue view ${{ github.event.issue.number }} --json title,body,labels \
+            --jq '"# " + .title + "\n\n" + (.body // "") + "\n\n## Existing Labels\n" + ([.labels[].name] | if length == 0 then "none" else join(", ") end)' \
+            > "$ISSUE_FILE"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Triage issue
         if: steps.scan.outputs.detected != 'true'
         uses: google-github-actions/run-gemini-cli@v0.1.21
@@ -66,9 +83,7 @@ jobs:
               "tools": {
                 "core": [
                   "read_file",
-                  "run_shell_command(gh)",
                   "run_shell_command(bash)",
-                  "run_shell_command(.github/scripts/update-comment.sh)",
                   "run_shell_command(echo)"
                 ]
               }
@@ -79,13 +94,62 @@ jobs:
 
             Triage GitHub issue #${{ github.event.issue.number }}.
 
-            Issue title: "${{ github.event.issue.title }}"
+            Read the issue content from `${{ steps.triage-path.outputs.issue }}`.
 
-            Use `gh issue view ${{ github.event.issue.number }}` to read the full issue body.
-            Then follow the triage-issue skill steps to classify and label it.
+            Classify the issue and write your triage output to
+            `${{ steps.triage-path.outputs.file }}`.
 
-            IMPORTANT: Follow the "Posting Comments" section in triage-issue.md
-            for in-place comment updates using the <!-- fullsend:triage-agent --> marker.
+            The output file MUST follow this exact format:
+
+            ```
+            LABELS: <comma-separated list of labels to add>
+            ---
+            <your triage summary in markdown>
+            ```
+
+            Example:
+            ```
+            LABELS: kind/bug,area/controller,priority/high,ready-for-implementation
+            ---
+            ### Triage Summary
+            - **Type**: kind/bug
+            - **Area**: area/controller
+            ...
+            ```
+
+            Do NOT use `gh` commands — you do not have access.
+            Do NOT post comments — a later step handles that.
+            Only read files and write the triage output file.
           upload_artifacts: 'true'
+
+      - name: Apply triage results
+        if: steps.scan.outputs.detected != 'true'
+        run: |
+          TRIAGE_FILE="${{ steps.triage-path.outputs.file }}"
+          if [ ! -f "$TRIAGE_FILE" ]; then
+            echo "::error::Triage agent did not produce $TRIAGE_FILE"
+            exit 1
+          fi
+
+          # Extract labels from the first line
+          LABELS=$(head -1 "$TRIAGE_FILE" | sed 's/^LABELS: //')
+          # Extract summary (everything after the --- separator)
+          SUMMARY=$(sed '1,/^---$/d' "$TRIAGE_FILE")
+
+          if [ -z "$LABELS" ]; then
+            echo "::warning::No labels found in triage output"
+          else
+            echo "Applying labels: $LABELS"
+            gh issue edit ${{ github.event.issue.number }} --add-label "$LABELS"
+          fi
+
+          if [ -z "$SUMMARY" ]; then
+            echo "::warning::No summary found in triage output"
+          else
+            echo "$SUMMARY" > /tmp/triage-summary.txt
+            MARKER="<!-- fullsend:triage-agent -->"
+            .github/scripts/update-comment.sh "${{ github.repository }}" \
+              "${{ github.event.issue.number }}" "$MARKER" @/tmp/triage-summary.txt
+          fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/triage-agent.yml
+++ b/.github/workflows/triage-agent.yml
@@ -131,8 +131,11 @@ jobs:
             exit 1
           fi
 
-          # Extract labels from the first line
-          LABELS=$(head -1 "$TRIAGE_FILE" | sed 's/^LABELS: //')
+          # Sanitize line endings first
+          sed -i 's/\r$//' "$TRIAGE_FILE"
+          
+          # Extract labels safely, ignoring potential markdown codeblock wrappers
+          LABELS=$(grep '^LABELS:' "$TRIAGE_FILE" | head -1 | sed 's/^LABELS:[[:space:]]*//')
           # Extract summary (everything after the --- separator)
           SUMMARY=$(sed '1,/^---$/d' "$TRIAGE_FILE")
 
@@ -146,7 +149,7 @@ jobs:
           if [ -z "$SUMMARY" ]; then
             echo "::warning::No summary found in triage output"
           else
-            echo "$SUMMARY" > /tmp/triage-summary.txt
+            printf "%s\n" "$SUMMARY" > /tmp/triage-summary.txt
             MARKER="<!-- fullsend:triage-agent -->"
             .github/scripts/update-comment.sh "${{ github.repository }}" \
               "${{ github.event.issue.number }}" "$MARKER" @/tmp/triage-summary.txt


### PR DESCRIPTION
## Summary
- Gemini CLI's environment sanitization strips `GH_TOKEN` from subprocesses in GitHub Actions, causing all `gh` CLI commands inside Gemini to fail with exit code 4 (not authenticated)
- Restructure the triage agent to match the review agent's pre-fetch + deterministic post-step pattern: pre-fetch issue data, have Gemini write triage results to a file, then a separate step applies labels and posts comments with proper auth
- Update `triage-issue.md` skill to reflect the new file-based output contract

## Changes
- **triage-agent.yml**: Add "Prepare triage inputs" step to pre-fetch issue data, remove `gh` and `update-comment.sh` from Gemini's tools, add "Apply triage results" post-step that reads Gemini's output file and runs `gh issue edit --add-label` + `update-comment.sh`
- **triage-issue.md**: Update skill to instruct Gemini to write structured output (`LABELS:` + `---` + summary) to a file instead of calling `gh` directly

## Test plan
- [ ] Create a test issue to trigger the triage agent workflow
- [ ] Verify Gemini produces the triage output file with correct format
- [ ] Verify labels are applied to the issue by the post-step
- [ ] Verify triage summary comment is posted on the issue
- [ ] Verify GH_TOKEN is not leaked in Gemini logs