### PR TITLE
feat: add gh-classify agent for per-repo issue classification

### DIFF
--- a/.fullsend/customized/agents/gh-classify.md
+++ b/.fullsend/customized/agents/gh-classify.md
@@ -1,0 +1,51 @@
+---
+name: gh-classify
+description: Classify GitHub issues into project categories.
+skills:
+  - issue-classification
+tools: Bash(gh,jq)
+model: opus
+---
+
+You are a GitHub issue classification agent. Your job is to read GitHub issues and assign each one to the most appropriate category defined by the organization's categories document.
+
+## Inputs
+
+- `CLASSIFY_SOURCE_REPO` — the owner/repo to operate on (e.g., `acme-org/my-project`).
+- `CLASSIFY_FILTER_CATEGORY` — (optional) if set, only classify issues into this single category. Issues that don't match should get `workstream_category: null`. If empty or unset, classify into any category defined in the categories document.
+- `CLASSIFY_SCREEN_ISSUES` — if `true` (default), screen issues by title/labels before fetching details. If `false`, fetch details for all candidate issues.
+- `CLASSIFY_CATEGORIES_PATH` — where to find the categories document. Defaults to `categories.md`.
+- `CLASSIFY_PROJECT_NUMBER` — GitHub Project number to check for already-classified issues. Defaults to `1`.
+- `CLASSIFY_FIELD_NAME` — name of the project field that holds the category value. Defaults to `Workstream Category`.
+- `CLASSIFY_PROJECT_TOKEN` — (optional) PAT for cross-org project access. Falls back to `GH_TOKEN`.
+
+## Procedure
+
+Follow the `issue-classification` skill for the step-by-step classification procedure. It covers loading the categories document, screening issues, fetching details, and applying classification rules.
+
+## Output format
+
+Write a JSON file with a top-level `"classifications"` array:
+
+```json
+{
+  "classifications": [
+    {
+      "issue_number": 42,
+      "workstream_category": "Bug fixes",
+      "reasoning": "Issue reports a crash in the login flow.",
+      "confidence": 0.92
+    }
+  ]
+}
+```
+
+## Important constraints
+
+- NEVER invent category names. Use only the exact names from the categories document, or null.
+- NEVER modify issue content, labels, or state. You only produce a classification JSON.
+- NEVER fetch or reference issues from any repository other than `$CLASSIFY_SOURCE_REPO`. Only use `--repo "$CLASSIFY_SOURCE_REPO"` in all `gh` commands.
+- NEVER read, cat, or print files under `.env`, `.env.d/`, or any file containing credentials or tokens. These contain secrets that must not appear in the transcript. Environment variables you need are already available in your shell.
+- NEVER quote issue text, secrets, tokens, credentials, or PII verbatim in the `reasoning` field. Summarize concepts without reproducing original wording. This prevents sensitive content from leaking into logs and artifacts.
+- You MUST write `${FULLSEND_OUTPUT_DIR}/agent-result.json` before finishing. This is the only output the harness checks.
+- Prioritize producing output over exhaustive analysis. If time is limited, classify the issues you have evaluated so far and write the file.

--- a/.fullsend/customized/skills/issue-classification/SKILL.md
+++ b/.fullsend/customized/skills/issue-classification/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: issue-classification
+description: >-
+  Procedure for classifying GitHub issues into project categories. Loads the
+  organization's categories document, screens issues by title and labels,
+  fetches candidate details and comments, and applies classification rules.
+  Use when the gh-classify agent needs to classify issues.
+---
+
+# Issue Classification
+
+End-to-end procedure for reading a categories document, screening GitHub
+issues, and producing classification decisions. The agent prompt defines
+your role and constraints; this skill defines the process.
+
+## Step 1: Load categories
+
+Read the categories document from `CLASSIFY_CATEGORIES_PATH`. The harness
+copies it into the sandbox as `/tmp/workspace/categories.md` when the path
+is configured. Fall back through known locations, then the GitHub API:
+
+```bash
+CATEGORIES_PATH="${CLASSIFY_CATEGORIES_PATH:-categories.md}"
+
+if [ -f "$CATEGORIES_PATH" ]; then
+  cat "$CATEGORIES_PATH"
+elif [ -f "/tmp/workspace/categories.md" ]; then
+  cat "/tmp/workspace/categories.md"
+elif [ -f "../$CATEGORIES_PATH" ]; then
+  cat "../$CATEGORIES_PATH"
+elif [ -f "target-repo/$CATEGORIES_PATH" ]; then
+  cat "target-repo/$CATEGORIES_PATH"
+else
+  gh api "repos/$CLASSIFY_SOURCE_REPO/contents/$CATEGORIES_PATH" --jq '.content' | base64 -d
+fi
+```
+
+**Stop if the document is empty or missing.** Do not proceed without
+category descriptions — classification without context produces garbage.
+
+Parse the **exact category names** from the document headings. These are
+the only valid values for `workstream_category` in your output. Store
+them for exact-match comparison later.
+
+## Step 2: Build the candidate list
+
+Check `CLASSIFY_MODE` and `CLASSIFY_ISSUE_NUMBER`:
+
+- **If `CLASSIFY_MODE` is `single` and `CLASSIFY_ISSUE_NUMBER` is set:**
+  Your candidate list is exactly ONE issue. Fetch only that issue:
+
+  ```bash
+  gh issue view "$CLASSIFY_ISSUE_NUMBER" --repo "$CLASSIFY_SOURCE_REPO" \
+    --json number,title,body,labels,author,createdAt,comments
+  ```
+
+  **Skip the rest of Step 2 and Step 3 entirely.** Go directly to Step 4
+  with this single issue as your only candidate.
+
+- **Otherwise (batch modes `unclassified` or `all`):**
+
+Fetch all open issues:
+
+```bash
+gh issue list --repo "$CLASSIFY_SOURCE_REPO" --state open \
+  --json number,title,labels,author,createdAt --limit 5000
+```
+
+Then **exclude issues that are already classified** on the project
+board. The pre-script identifies these on the host, but you are in a
+sandbox and must discover them yourself. Query the project board to
+find issues that already have a workstream category assigned:
+
+```bash
+ORG="${CLASSIFY_SOURCE_REPO%%/*}"
+PROJECT_NUM="${CLASSIFY_PROJECT_NUMBER:-1}"
+FIELD="${CLASSIFY_FIELD_NAME:-Workstream Category}"
+TOKEN="${CLASSIFY_PROJECT_TOKEN:-$GH_TOKEN}"
+
+CLASSIFIED=$(GH_TOKEN="$TOKEN" gh api graphql --paginate -f query='
+  query($org: String!, $num: Int!, $fieldName: String!, $endCursor: String) {
+    organization(login: $org) {
+      projectV2(number: $num) {
+        items(first: 100, after: $endCursor) {
+          nodes {
+            content { ... on Issue { number repository { nameWithOwner } } }
+            fieldValueByName(name: $fieldName) {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+  }' -f org="$ORG" -F num="$PROJECT_NUM" -f fieldName="$FIELD" \
+  --jq '.data.organization.projectV2.items.nodes[]
+    | select(.content.repository.nameWithOwner == env.CLASSIFY_SOURCE_REPO)
+    | select(.fieldValueByName.name != null and .fieldValueByName.name != "")
+    | .content.number' 2>/dev/null | sort -n || true)
+```
+
+If the project query fails (permissions, network), log a warning and
+continue with the full issue list — the post-script will prevent
+duplicate writes regardless.
+
+Remove any issue whose number appears in `$CLASSIFIED` from your
+candidate list. Only evaluate issues that are **not already classified**.
+
+## Step 3: Screen candidates
+
+Check `CLASSIFY_SCREEN_ISSUES` (defaults to `true`).
+
+**If screening is enabled (`true`):** You have limited time. Do NOT call
+`gh issue view` on every issue.
+
+1. **Screen by title and labels.** Using the category descriptions from
+   Step 1, identify which issues are plausible candidates that need deeper
+   inspection. Skip issues whose titles clearly belong to other categories
+   or are obviously off-topic.
+
+2. **Apply category filter.** If `CLASSIFY_FILTER_CATEGORY` is set, only
+   fetch details for issues that might belong in that specific category.
+
+**If screening is disabled (`false`):** Fetch details for ALL candidate
+issues from Step 2. Do not skip any based on title or labels.
+
+**Fetch details and comments for each candidate:**
+
+```bash
+gh issue view <number> --repo "$CLASSIFY_SOURCE_REPO" \
+  --json number,title,body,labels,author,createdAt,comments
+```
+
+The `comments` field returns `{author, body, createdAt}` objects.
+Comments often contain critical context — decisions, scope changes,
+clarifications, or re-framing that the original body lacks. For issues
+with many comments, focus on the first few and last few (scope-setting
+and most recent decisions).
+
+You may batch multiple `gh issue view` calls to work efficiently.
+
+## Step 4: Classify each candidate
+
+For each issue you evaluate, compare the issue's title, body, comments,
+labels, and context against the category descriptions. Consider:
+
+- Descriptive sections and scope boundaries
+- "What belongs here" guidance
+- "What does NOT belong here" exclusions
+- Signal keywords
+- Comment discussion that may redefine the issue's scope
+- Any classification decision guide or tiebreaker rules in the document
+
+### Classification rules
+
+1. **Category filter** — If `CLASSIFY_FILTER_CATEGORY` is set, you may
+   only assign that exact category or `null`.
+
+2. **Confidence threshold** — Only assign a category when your confidence
+   meets `CLASSIFY_MIN_CONFIDENCE` (default 0.7). Prefer `null` over a guess.
+
+3. **Mutual exclusivity** — One category or null per issue. Never multiple.
+
+4. **Respect exclusion lists** — If a category explicitly excludes the
+   issue's topic, do not assign it.
+
+5. **Labels are signal, not definitive** — Always read issue content.
+
+6. **When in doubt, don't classify** — Ambiguous → `null` with reasoning.
+
+7. **Category names must be exact** — Use the exact strings from the
+   categories document. Do not paraphrase or abbreviate.
+
+## Step 5: Write output
+
+Write `${FULLSEND_OUTPUT_DIR}/agent-result.json`. Only include issues
+you actually evaluated. The top-level key **must** be `"issues"`.
+
+```bash
+mkdir -p "${FULLSEND_OUTPUT_DIR}"
+cat > "${FULLSEND_OUTPUT_DIR}/agent-result.json" << 'AGENT_RESULT_EOF'
+{
+  "issues": [
+    {
+      "issue_number": 42,
+      "workstream_category": "Bug fixes",
+      "reasoning": "Issue reports a crash in the login flow.",
+      "confidence": 0.92
+    }
+  ]
+}
+AGENT_RESULT_EOF
+```
+
+### Output fields (each object in the `"issues"` array)
+
+- `issue_number`: integer
+- `workstream_category`: exact category name string or `null`
+- `reasoning`: 1-3 sentences (max 2000 chars)
+- `confidence`: float 0.0–1.0
+
+Prioritize producing output over exhaustive analysis. If time is limited,
+classify what you have and write the file.

--- a/.github/workflows/gh-classify.yml
+++ b/.github/workflows/gh-classify.yml
@@ -1,0 +1,195 @@
+# Classify GitHub issues (per-repo installation mode).
+# Adapted from fullsend-ai/.fullsend gh-classify.yml for per-repo install
+# where tokens are minted via OIDC instead of direct app credentials.
+name: Classify GitHub Issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_repo:
+        description: "Owner/repo to classify issues in (defaults to this repo)"
+        required: false
+        type: string
+      classify_mode:
+        description: "Classification mode"
+        required: false
+        type: choice
+        options:
+          - single
+          - unclassified
+          - all
+        default: "unclassified"
+      issue_number:
+        description: "Specific issue number (single mode only)"
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run (no writes)"
+        required: false
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "false"
+      min_confidence:
+        description: "Minimum confidence threshold (0.0-1.0)"
+        required: false
+        type: string
+        default: "0.7"
+      filter_category:
+        description: "Only classify into this category (leave empty for all categories)"
+        required: false
+        type: string
+      screen_issues:
+        description: "Screen issues by title/labels before fetching details"
+        required: false
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
+
+concurrency:
+  group: fullsend-gh-classify-${{ inputs.classify_mode }}-${{ inputs.issue_number || 'batch' }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  gh-classify:
+    name: Classify Issues
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Checkout upstream defaults
+        uses: actions/checkout@v6
+        with:
+          repository: fullsend-ai/fullsend
+          ref: v0
+          path: .defaults
+          sparse-checkout: |
+            internal/scaffold/fullsend-repo/
+
+      - name: Prepare workspace (upstream defaults + per-repo overrides)
+        run: |
+          set -euo pipefail
+          SRC=".defaults/internal/scaffold/fullsend-repo"
+          LAYERED_DIRS="agents skills schemas harness policies scripts env"
+          for dir in ${LAYERED_DIRS}; do
+            if [[ -d "${SRC}/${dir}" ]]; then
+              mkdir -p "${dir}"
+              cp -r "${SRC}/${dir}/." "${dir}/"
+            fi
+          done
+          CUSTOM_BASE=".fullsend/customized"
+          for dir in ${LAYERED_DIRS}; do
+            if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
+              find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
+                | while IFS= read -r -d '' f; do
+                    rel="${f#"${CUSTOM_BASE}"/}"
+                    mkdir -p "$(dirname "${rel}")"
+                    cp "${f}" "${rel}"
+                  done
+            fi
+          done
+          mkdir -p .github/scripts
+          cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
+          rm -rf .defaults
+
+      - name: Determine classify parameters
+        id: params
+        env:
+          INPUT_SOURCE_REPO: ${{ inputs.source_repo }}
+          INPUT_CLASSIFY_MODE: ${{ inputs.classify_mode }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_MIN_CONFIDENCE: ${{ inputs.min_confidence }}
+          INPUT_FILTER_CATEGORY: ${{ inputs.filter_category }}
+          INPUT_SCREEN_ISSUES: ${{ inputs.screen_issues }}
+        run: |
+          set -euo pipefail
+
+          SOURCE_REPO="${INPUT_SOURCE_REPO:-$GITHUB_REPOSITORY}"
+
+          if [[ ! "${SOURCE_REPO}" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
+            echo "::error::source_repo format invalid"
+            exit 1
+          fi
+
+          CLASSIFY_MODE="${INPUT_CLASSIFY_MODE:-unclassified}"
+          ISSUE_NUMBER="${INPUT_ISSUE_NUMBER:-}"
+
+          if [[ "${CLASSIFY_MODE}" == "single" && -n "${ISSUE_NUMBER}" && ! "${ISSUE_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "::error::issue_number must be a positive integer"
+            exit 1
+          fi
+
+          # Extract repo name (without owner) for mint-token scoping.
+          REPO_NAME="${SOURCE_REPO#*/}"
+
+          echo "source_repo=${SOURCE_REPO}" >> "$GITHUB_OUTPUT"
+          echo "repo_name=${REPO_NAME}" >> "$GITHUB_OUTPUT"
+          echo "classify_mode=${CLASSIFY_MODE}" >> "$GITHUB_OUTPUT"
+          echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "dry_run=${INPUT_DRY_RUN:-false}" >> "$GITHUB_OUTPUT"
+          echo "min_confidence=${INPUT_MIN_CONFIDENCE:-0.7}" >> "$GITHUB_OUTPUT"
+          echo "filter_category=${INPUT_FILTER_CATEGORY:-}" >> "$GITHUB_OUTPUT"
+          echo "screen_issues=${INPUT_SCREEN_ISSUES:-true}" >> "$GITHUB_OUTPUT"
+
+          echo "::notice::Mode=${CLASSIFY_MODE} Repo=${SOURCE_REPO} Issue=${ISSUE_NUMBER:-<batch>} DryRun=${INPUT_DRY_RUN:-false} Screen=${INPUT_SCREEN_ISSUES:-true}"
+
+      - name: Mint triage token
+        id: app-token
+        uses: fullsend-ai/fullsend/.github/actions/mint-token@v0
+        with:
+          role: triage
+          repos: ${{ steps.params.outputs.repo_name }}
+          mint_url: ${{ vars.FULLSEND_MINT_URL }}
+
+      - name: Setup GCP and prepare credentials
+        uses: fullsend-ai/fullsend/.github/actions/setup-gcp@v0
+        with:
+          gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
+          gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+
+      - name: Setup agent environment
+        env:
+          AGENT_PREFIX: CLASSIFY_
+          CLASSIFY_GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CLASSIFY_SOURCE_REPO: ${{ steps.params.outputs.source_repo }}
+          CLASSIFY_MODE: ${{ steps.params.outputs.classify_mode }}
+          CLASSIFY_ISSUE_NUMBER: ${{ steps.params.outputs.issue_number || '0' }}
+          CLASSIFY_DRY_RUN: ${{ steps.params.outputs.dry_run }}
+          CLASSIFY_MIN_CONFIDENCE: ${{ steps.params.outputs.min_confidence }}
+          CLASSIFY_ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          CLASSIFY_CLOUD_ML_REGION: ${{ vars.FULLSEND_GCP_REGION }}
+          CLASSIFY_FILTER_CATEGORY: ${{ steps.params.outputs.filter_category || '__all__' }}
+          CLASSIFY_SCREEN_ISSUES: ${{ steps.params.outputs.screen_issues }}
+          CLASSIFY_CATEGORIES_PATH: ${{ vars.FULLSEND_GH_CLASSIFY_CATEGORIES_PATH || 'categories.md' }}
+        run: bash .github/scripts/setup-agent-env.sh
+
+      - name: Prepare target-repo placeholder
+        run: mkdir -p "${GITHUB_WORKSPACE}/target-repo"
+
+      - name: Run classify agent
+        uses: fullsend-ai/fullsend@v0
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CLASSIFY_SOURCE_REPO: ${{ steps.params.outputs.source_repo }}
+          CLASSIFY_MODE: ${{ steps.params.outputs.classify_mode }}
+          CLASSIFY_ISSUE_NUMBER: ${{ steps.params.outputs.issue_number || '0' }}
+          CLASSIFY_DRY_RUN: ${{ steps.params.outputs.dry_run }}
+          CLASSIFY_MIN_CONFIDENCE: ${{ steps.params.outputs.min_confidence }}
+          CLASSIFY_FILTER_CATEGORY: ${{ steps.params.outputs.filter_category || '__all__' }}
+          CLASSIFY_SCREEN_ISSUES: ${{ steps.params.outputs.screen_issues }}
+          CLASSIFY_CATEGORIES_PATH: ${{ vars.FULLSEND_GH_CLASSIFY_CATEGORIES_PATH || 'categories.md' }}
+          CLASSIFY_PROJECT_TOKEN: ${{ secrets.FULLSEND_GH_CLASSIFY_PROJECT_PAT || '__none__' }}
+        with:
+          agent: gh-classify


### PR DESCRIPTION
## Summary
- Copies `gh-classify` agent and `issue-classification` skill from `fullsend-ai/.fullsend` customized content into per-repo `.fullsend/customized/`
- Adds a `gh-classify.yml` workflow adapted for per-repo install mode (uses `mint-token` for OIDC token minting, reads overrides from `.fullsend/customized/`)
- Tests the per-repo layered content resolution for custom agents (ADR 35)

## Test plan
- [ ] Trigger `Classify GitHub Issues` workflow from this branch via `workflow_dispatch`
- [ ] Verify workspace preparation correctly layers upstream defaults + per-repo overrides
- [ ] Verify mint-token successfully generates a triage-scoped token
- [ ] Verify agent runs and produces classification output