### PR TITLE
Fix missing env vars in gh-classify workflow

### DIFF
--- a/.github/workflows/gh-classify.yml
+++ b/.github/workflows/gh-classify.yml
@@ -187,6 +187,8 @@ jobs:
           CLASSIFY_ISSUE_NUMBER: ${{ steps.params.outputs.issue_number || '0' }}
           CLASSIFY_DRY_RUN: ${{ steps.params.outputs.dry_run }}
           CLASSIFY_MIN_CONFIDENCE: ${{ steps.params.outputs.min_confidence }}
+          CLASSIFY_PROJECT_NUMBER: ${{ vars.FULLSEND_GH_CLASSIFY_PROJECT_NUMBER || vars.FULLSEND_PROJECT_NUMBER || '1' }}
+          CLASSIFY_FIELD_NAME: ${{ vars.FULLSEND_GH_CLASSIFY_FIELD_NAME || 'Workstream Category' }}
           CLASSIFY_FILTER_CATEGORY: ${{ steps.params.outputs.filter_category || '__all__' }}
           CLASSIFY_SCREEN_ISSUES: ${{ steps.params.outputs.screen_issues }}
           CLASSIFY_CATEGORIES_PATH: ${{ vars.FULLSEND_GH_CLASSIFY_CATEGORIES_PATH || 'categories.md' }}


### PR DESCRIPTION
## Summary
- Adds `CLASSIFY_PROJECT_NUMBER` and `CLASSIFY_FIELD_NAME` env vars to both the "Setup agent environment" and "Run classify agent" steps
- These are required by the harness `runner_env` validation but were missing from the per-repo workflow
- Uses the same `vars.*` references and defaults as the org-level workflow in `fullsend-ai/.fullsend`

## Test plan
- [ ] Merge and trigger `gh-classify` workflow — should pass env validation