### PR TITLE
fix: update gh-classify policy to OpenShell v0.0.38 schema

### DIFF
--- a/.fullsend/customized/policies/gh-classify.yaml
+++ b/.fullsend/customized/policies/gh-classify.yaml
@@ -1,3 +1,5 @@
+# gh-classify agent policy — classify issues into workstream categories.
+# Read-only GitHub access (issues, labels, projects).
 version: 1
 
 filesystem_policy:
@@ -14,16 +16,23 @@ network_policies:
   vertex_ai:
     name: vertex-ai
     endpoints:
-      - host: "*.github.com"
-        port: 443
-        protocol: tcp
-        enforcement: enforce
-        access: allow
       - host: "*.googleapis.com"
         port: 443
-        protocol: tcp
+        protocol: rest
         enforcement: enforce
-        access: allow
+        access: read-write
+    binaries:
+      - path: "**/claude"
+      - path: "**/node"
+
+  github_api:
+    name: github-api
+    endpoints:
+      - host: "*.github.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
     binaries:
       - path: "**/curl"
       - path: "**/claude"


### PR DESCRIPTION
## Summary

- Update gh-classify sandbox policy to OpenShell v0.0.38 network policy schema
- `protocol: tcp` → `protocol: rest` (v0.0.38 enforces protocol-aware inspection)
- `access: allow` → `access: read-write` / `read-only` (v0.0.38 granular access levels)
- Separate `vertex_ai` and `github_api` into distinct network policies (GitHub API is read-only, Vertex AI is read-write)
- Remove `**/curl` from `vertex_ai` binaries (curl should only access GitHub API, not Vertex AI)
- Add comment header for consistency with upstream scaffold policies

## Test plan

- [x] Verified locally with `fullsend run gh-classify` against this repo — agent exits 0, output validates against `gh-classify-result.schema.json`